### PR TITLE
Add a way to exclude orgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,50 +13,52 @@ For human readable output:
 Gathering usage information
 Org platform-eng is consuming 53400 MB of 204800 MB.
 	Space CFbook is consuming 128 MB memory (0%) of org quota.
-		1 apps: 1 running 0 stopped
+		1 apps: 1 running, 0 stopped
 		1 instances: 1 running, 0 stopped
 Org krujos is consuming 512 MB of 10240 MB.
 	Space development is consuming 0 MB memory (0%) of org quota.
-		4 apps: 0 running 4 stopped
+		4 apps: 0 running, 4 stopped
 		4 instances: 0 running, 4 stopped
 	Space production is consuming 512 MB memory (5%) of org quota.
-		1 apps: 1 running 0 stopped
+		1 apps: 1 running, 0 stopped
 		2 instances: 2 running, 0 stopped
 Org pcfp is consuming 7296 MB of 102400 MB.
 	Space development is consuming 0 MB memory (0%) of org quota.
-		0 apps: 0 running 0 stopped
+		0 apps: 0 running, 0 stopped
 		0 instances: 0 running, 0 stopped
 	Space docs-staging is consuming 512 MB memory (0%) of org quota.
-		2 apps: 1 running 1 stopped
+		2 apps: 1 running, 1 stopped
 		4 instances: 2 running, 2 stopped
 	Space docs-prod is consuming 512 MB memory (0%) of org quota.
-		3 apps: 1 running 2 stopped
+		3 apps: 1 running, 2 stopped
 		5 instances: 2 running, 3 stopped
 	Space guillermo-playground is consuming 2560 MB memory (2%) of org quota.
-		1 apps: 1 running 0 stopped
+		1 apps: 1 running, 0 stopped
 		5 instances: 5 running, 0 stopped
 	Space haydon-playground is consuming 1024 MB memory (1%) of org quota.
-		1 apps: 1 running 0 stopped
+		1 apps: 1 running, 0 stopped
 		1 instances: 1 running, 0 stopped
 	Space jkruck-playground is consuming 128 MB memory (0%) of org quota.
-		1 apps: 1 running 0 stopped
+		1 apps: 1 running, 0 stopped
 		1 instances: 1 running, 0 stopped
 	Space rsalas-dev is consuming 0 MB memory (0%) of org quota.
-		0 apps: 0 running 0 stopped
+		0 apps: 0 running, 0 stopped
 		0 instances: 0 running, 0 stopped
 	Space shekel-dev is consuming 1536 MB memory (1%) of org quota.
-		3 apps: 3 running 0 stopped
+		3 apps: 3 running, 0 stopped
 		3 instances: 3 running, 0 stopped
 	Space shekel-qa is consuming 0 MB memory (0%) of org quota.
-		0 apps: 0 running 0 stopped
+		0 apps: 0 running, 0 stopped
 		0 instances: 0 running, 0 stopped
 	Space hd-playground is consuming 0 MB memory (0%) of org quota.
-		0 apps: 0 running 0 stopped
+		0 apps: 0 running, 0 stopped
 		0 instances: 0 running, 0 stopped
 	Space dwallraff-dev is consuming 1024 MB memory (1%) of org quota.
-		1 apps: 1 running 0 stopped
+		1 apps: 1 running, 0 stopped
 		1 instances: 1 running, 0 stopped
 You are running 18 apps in 3 orgs, with a total of 27 instances.
+		18 apps: 11 running, 7 stopped
+		27 instances: 18 running, 9 stopped
 ```
 
 CSV output:

--- a/models/fixtures/result.txt
+++ b/models/fixtures/result.txt
@@ -1,5 +1,7 @@
 Org test-org is consuming 256 MB of 4096 MB.
 	Space test-space is consuming 256 MB memory (6%) of org quota.
-		2 apps: 1 running 1 stopped
+		2 apps: 1 running, 1 stopped
 		3 instances: 2 running, 1 stopped
 You are running 2 apps in 1 org(s), with a total of 3 instances.
+		2 apps: 1 running, 1 stopped
+		3 instances: 2 running, 1 stopped

--- a/models/models.go
+++ b/models/models.go
@@ -87,7 +87,9 @@ func (report *Report) String() string {
 	var response bytes.Buffer
 
 	totalApps := 0
+	totalAppsRunning := 0
 	totalInstances := 0
+	totalInstancesRunning := 0
 
 	for _, org := range report.Orgs {
 		response.WriteString(fmt.Sprintf("Org %s is consuming %d MB of %d MB.\n",
@@ -99,15 +101,20 @@ func (report *Report) String() string {
 			spaceRunningInstancesCount := space.RunningInstancesCount()
 			spaceConsumedMemory := space.ConsumedMemory()
 
+			spaceStoppedInstancesCount := spaceInstancesCount - spaceRunningInstancesCount
+
 			response.WriteString(
 				fmt.Sprintf("\tSpace %s is consuming %d MB memory (%d%%) of org quota.\n",
 					space.Name, spaceConsumedMemory, (100 * spaceConsumedMemory / org.MemoryQuota)))
 			response.WriteString(
-				fmt.Sprintf("\t\t%d apps: %d running %d stopped\n", len(space.Apps),
+				fmt.Sprintf("\t\t%d apps: %d running, %d stopped\n", len(space.Apps),
 					spaceRunningAppsCount, len(space.Apps)-spaceRunningAppsCount))
 			response.WriteString(
 				fmt.Sprintf("\t\t%d instances: %d running, %d stopped\n", spaceInstancesCount,
-					spaceRunningInstancesCount, spaceInstancesCount-spaceRunningInstancesCount))
+					spaceRunningInstancesCount, spaceStoppedInstancesCount))
+
+			totalInstancesRunning += spaceRunningInstancesCount
+			totalAppsRunning += spaceRunningAppsCount
 		}
 
 		totalApps += org.AppsCount()
@@ -117,6 +124,12 @@ func (report *Report) String() string {
 	response.WriteString(
 		fmt.Sprintf("You are running %d apps in %d org(s), with a total of %d instances.\n",
 			totalApps, len(report.Orgs), totalInstances))
+	response.WriteString(
+		fmt.Sprintf("\t\t%d apps: %d running, %d stopped\n",
+			totalApps, totalAppsRunning, totalApps-totalAppsRunning))
+	response.WriteString(
+		fmt.Sprintf("\t\t%d instances: %d running, %d stopped\n",
+			totalInstances, totalInstancesRunning, totalInstances-totalInstancesRunning))
 
 	return response.String()
 }


### PR DESCRIPTION
This would allow specified orgs to be excluded from the report.  
e.g. cf usage-report -e "org1" or cf usage-report -e "org1" -e "org2"